### PR TITLE
AYS-161 | Update phone number test data

### DIFF
--- a/src/test/java/org/ays/tests/auth/institutionAuthServiseTests/GetAdminTokenTest.java
+++ b/src/test/java/org/ays/tests/auth/institutionAuthServiseTests/GetAdminTokenTest.java
@@ -5,7 +5,6 @@ import org.ays.endpoints.InstitutionAuthEndpoints;
 import org.ays.payload.AdminCredentials;
 import org.ays.payload.Helper;
 import org.ays.utility.AysResponseSpecs;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class GetAdminTokenTest {
@@ -14,8 +13,8 @@ public class GetAdminTokenTest {
         AdminCredentials adminCredentials = Helper.setIntsAdminCredentials();
         Response response = InstitutionAuthEndpoints.getAdminToken(adminCredentials);
         response.then()
-                .spec(AysResponseSpecs.successResponseSpec())
-                .spec(AysResponseSpecs.getTokenResponseSpec());
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectGetTokenResponseSpec());
     }
 
     @Test
@@ -25,6 +24,6 @@ public class GetAdminTokenTest {
         adminCredentials.setPassword("1234");
         Response response = InstitutionAuthEndpoints.getAdminToken(adminCredentials);
         response.then()
-                .spec(AysResponseSpecs.unauthorizedResponseSpec());
+                .spec(AysResponseSpecs.expectUnauthorizedResponseSpec());
     }
 }

--- a/src/test/java/org/ays/tests/auth/institutionAuthServiseTests/PostAdminInvalidateTokenTest.java
+++ b/src/test/java/org/ays/tests/auth/institutionAuthServiseTests/PostAdminInvalidateTokenTest.java
@@ -16,6 +16,6 @@ public class PostAdminInvalidateTokenTest {
         refreshToken.setRefreshToken(token.getRefreshToken());
         Response response = InstitutionAuthEndpoints.adminInvalidateToken(token.getAccessToken(), refreshToken);
         response.then()
-                .spec(AysResponseSpecs.successResponseSpec());
+                .spec(AysResponseSpecs.expectSuccessResponseSpec());
     }
 }

--- a/src/test/java/org/ays/tests/auth/institutionAuthServiseTests/PostAdminTokenRefreshTest.java
+++ b/src/test/java/org/ays/tests/auth/institutionAuthServiseTests/PostAdminTokenRefreshTest.java
@@ -15,8 +15,8 @@ public class PostAdminTokenRefreshTest {
         refreshToken.setRefreshToken(Helper.getAdminRefreshToken(Helper.setIntsAdminCredentials()));
         Response response = InstitutionAuthEndpoints.adminTokenRefresh(refreshToken);
         response.then()
-                .spec(AysResponseSpecs.successResponseSpec())
-                .spec(AysResponseSpecs.getTokenResponseSpec());
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectGetTokenResponseSpec());
     }
     @Test
     public void testAdminInvalidRefreshTokenForAccessTokenCreation() {
@@ -26,6 +26,6 @@ public class PostAdminTokenRefreshTest {
         InstitutionAuthEndpoints.adminInvalidateToken(token.getAccessToken(), refreshToken);
         Response response = InstitutionAuthEndpoints.adminTokenRefresh(refreshToken);
         response.then()
-                .spec(AysResponseSpecs.unauthorizedResponseSpec());
+                .spec(AysResponseSpecs.expectUnauthorizedResponseSpec());
     }
 }

--- a/src/test/java/org/ays/tests/auth/userAuthServiceTests/GetUserTokenTest.java
+++ b/src/test/java/org/ays/tests/auth/userAuthServiceTests/GetUserTokenTest.java
@@ -20,8 +20,8 @@ public class GetUserTokenTest {
     public void getTokenForValidUser() {
         Response response = UserAuthEndpoints.getUserToken(userCredentials);
         response.then()
-                .spec(AysResponseSpecs.successResponseSpec())
-                .spec(AysResponseSpecs.getTokenResponseSpec());
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectGetTokenResponseSpec());
     }
 
     @Test
@@ -29,7 +29,7 @@ public class GetUserTokenTest {
         userCredentials.setPassword("wrongPassword");
         Response response = UserAuthEndpoints.getUserToken(userCredentials);
         response.then()
-                .spec(AysResponseSpecs.unauthorizedResponseSpec());
+                .spec(AysResponseSpecs.expectUnauthorizedResponseSpec());
     }
 
     @Test
@@ -37,7 +37,7 @@ public class GetUserTokenTest {
         userCredentials.setUsername("wrongUserName");
         Response response = UserAuthEndpoints.getUserToken(userCredentials);
         response.then()
-                .spec(AysResponseSpecs.unauthorizedResponseSpec());
+                .spec(AysResponseSpecs.expectUnauthorizedResponseSpec());
 
     }
 
@@ -46,8 +46,8 @@ public class GetUserTokenTest {
         userCredentials.setUsername(null);
         Response response = UserAuthEndpoints.getUserToken(userCredentials);
         response.then()
-                .spec(AysResponseSpecs.badRequestResponseSpec())
-                .spec(AysResponseSpecs.nullCredentialFieldErrorSpec("username"));
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec())
+                .spec(AysResponseSpecs.expectNullCredentialFieldErrorSpec("username"));
     }
 
     @Test
@@ -55,7 +55,7 @@ public class GetUserTokenTest {
         userCredentials.setPassword(null);
         Response response = UserAuthEndpoints.getUserToken(userCredentials);
         response.then()
-                .spec(AysResponseSpecs.badRequestResponseSpec())
-                .spec(AysResponseSpecs.nullCredentialFieldErrorSpec("password"));
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec())
+                .spec(AysResponseSpecs.expectNullCredentialFieldErrorSpec("password"));
     }
 }

--- a/src/test/java/org/ays/tests/auth/userAuthServiceTests/PostUserInvalidateTokenTest.java
+++ b/src/test/java/org/ays/tests/auth/userAuthServiceTests/PostUserInvalidateTokenTest.java
@@ -7,7 +7,6 @@ import org.ays.payload.RefreshToken;
 import org.ays.payload.Token;
 import org.ays.payload.UserCredentials;
 import org.ays.utility.AysResponseSpecs;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class PostUserInvalidateTokenTest {
@@ -19,6 +18,6 @@ public class PostUserInvalidateTokenTest {
         refreshToken.setRefreshToken(token.getRefreshToken());
         Response response = UserAuthEndpoints.userInvalidateToken(token.getAccessToken(), refreshToken);
         response.then()
-                .spec(AysResponseSpecs.successResponseSpec());
+                .spec(AysResponseSpecs.expectSuccessResponseSpec());
     }
 }

--- a/src/test/java/org/ays/tests/auth/userAuthServiceTests/PostUserTokenRefreshTest.java
+++ b/src/test/java/org/ays/tests/auth/userAuthServiceTests/PostUserTokenRefreshTest.java
@@ -25,8 +25,8 @@ public class PostUserTokenRefreshTest {
         refreshToken.setRefreshToken(Helper.getUserRefreshToken(userCredentials));
         Response response = UserAuthEndpoints.userTokenRefresh(refreshToken);
         response.then()
-                .spec(AysResponseSpecs.successResponseSpec())
-                .spec(AysResponseSpecs.getTokenResponseSpec());
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectGetTokenResponseSpec());
     }
 
     @Test
@@ -37,6 +37,6 @@ public class PostUserTokenRefreshTest {
         UserAuthEndpoints.userInvalidateToken(token.getAccessToken(), refreshToken);
         Response response = InstitutionAuthEndpoints.adminTokenRefresh(refreshToken);
         response.then()
-                .spec(AysResponseSpecs.unauthorizedResponseSpec());
+                .spec(AysResponseSpecs.expectUnauthorizedResponseSpec());
     }
 }

--- a/src/test/java/org/ays/tests/institution/adminregistrationmanagementservice/PostAdminRegistrationApplicationRejectTest.java
+++ b/src/test/java/org/ays/tests/institution/adminregistrationmanagementservice/PostAdminRegistrationApplicationRejectTest.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class PostAdminRegistrationApplicationRejectTest extends DataProvider {
+public class PostAdminRegistrationApplicationRejectTest {
     String applicationID;
     RejectReason reason;
 
@@ -46,7 +46,7 @@ public class PostAdminRegistrationApplicationRejectTest extends DataProvider {
                         containsString("WAITING")));
     }
 
-    @Test(dataProvider = "invalidRejectReason")
+    @Test(dataProvider = "invalidRejectReason",dataProviderClass = DataProvider.class)
     @Story("As a super admin when I approve an application with reason field less than 40 or more than 512 characters I want to get proper error message")
     @Severity(SeverityLevel.NORMAL)
     public void rejectAnApplicationWithInvalidReason(String invalidRejectReason) {

--- a/src/test/java/org/ays/tests/institution/adminregistrationmanagementservice/PostAdminRegistrationApplicationRejectTest.java
+++ b/src/test/java/org/ays/tests/institution/adminregistrationmanagementservice/PostAdminRegistrationApplicationRejectTest.java
@@ -46,7 +46,7 @@ public class PostAdminRegistrationApplicationRejectTest {
                         containsString("WAITING")));
     }
 
-    @Test(dataProvider = "invalidRejectReason",dataProviderClass = DataProvider.class)
+    @Test(dataProvider = "invalidRejectReason", dataProviderClass = DataProvider.class)
     @Story("As a super admin when I approve an application with reason field less than 40 or more than 512 characters I want to get proper error message")
     @Severity(SeverityLevel.NORMAL)
     public void rejectAnApplicationWithInvalidReason(String invalidRejectReason) {

--- a/src/test/java/org/ays/tests/institution/adminregistrationmanagementservice/PostAdminRegistrationApplicationTest.java
+++ b/src/test/java/org/ays/tests/institution/adminregistrationmanagementservice/PostAdminRegistrationApplicationTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class PostAdminRegistrationApplicationTest{
+public class PostAdminRegistrationApplicationTest {
     ApplicationRegistration application;
 
     @BeforeMethod
@@ -36,7 +36,7 @@ public class PostAdminRegistrationApplicationTest{
                 .body("response", hasKey("id"));
     }
 
-    @Test(dataProvider = "invalidDataForPostApplicationReasonField",dataProviderClass = DataProvider.class)
+    @Test(dataProvider = "invalidDataForPostApplicationReasonField", dataProviderClass = DataProvider.class)
     public void createAnAdminRegistrationApplicationWithInvalidInputs(String reason, String message, String field, String type) {
         application = Helper.generateApplicationRegistrationPayloadWithoutReason();
         application.setReason(reason);

--- a/src/test/java/org/ays/tests/institution/adminregistrationmanagementservice/PostAdminRegistrationApplicationTest.java
+++ b/src/test/java/org/ays/tests/institution/adminregistrationmanagementservice/PostAdminRegistrationApplicationTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class PostAdminRegistrationApplicationTest extends DataProvider {
+public class PostAdminRegistrationApplicationTest{
     ApplicationRegistration application;
 
     @BeforeMethod
@@ -36,7 +36,7 @@ public class PostAdminRegistrationApplicationTest extends DataProvider {
                 .body("response", hasKey("id"));
     }
 
-    @Test(dataProvider = "invalidDataForPostApplicationReasonField")
+    @Test(dataProvider = "invalidDataForPostApplicationReasonField",dataProviderClass = DataProvider.class)
     public void createAnAdminRegistrationApplicationWithInvalidInputs(String reason, String message, String field, String type) {
         application = Helper.generateApplicationRegistrationPayloadWithoutReason();
         application.setReason(reason);

--- a/src/test/java/org/ays/tests/institution/assignmentmanagementservice/PostAssignmentTest.java
+++ b/src/test/java/org/ays/tests/institution/assignmentmanagementservice/PostAssignmentTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class PostAssignmentTest extends DataProvider {
+public class PostAssignmentTest {
     Assignment assignment;
 
     @BeforeMethod
@@ -35,7 +35,7 @@ public class PostAssignmentTest extends DataProvider {
 
     }
 
-    @Test(dataProvider = "invalidDescriptionData")
+    @Test(dataProvider = "invalidDescriptionData",dataProviderClass = DataProvider.class)
     @Story("As an admin when I create an assignment with invalid description I want to get a proper error messages.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidDescription(String invalidDescription, String errorMessage) {
@@ -48,7 +48,7 @@ public class PostAssignmentTest extends DataProvider {
                 .body("subErrors[0].type", equalTo("String"));
     }
 
-    @Test(dataProvider = "invalidCountryCodeData")
+    @Test(dataProvider = "invalidCountryCodeData",dataProviderClass = DataProvider.class)
     @Story("As an admin when I create an assignment with invalid country code input I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidCountryCode(String countryCode) {
@@ -72,7 +72,7 @@ public class PostAssignmentTest extends DataProvider {
     }
 
 
-    @Test(dataProvider = "invalidLineNumberData")
+    @Test(dataProvider = "invalidLineNumberData",dataProviderClass = DataProvider.class)
     @Story("As an admin user when I create an assignment with invalid line number I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidLineNumber(String lineNumber) {
@@ -95,7 +95,7 @@ public class PostAssignmentTest extends DataProvider {
         }
     }
 
-    @Test(dataProvider = "invalidLongitudeValues")
+    @Test(dataProvider = "invalidLongitudeValues",dataProviderClass = DataProvider.class)
     @Story("As an admin user when I create an assignment with invalid longitude input I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidLongitude(Double invalidLongitude, String errorMessage) {
@@ -110,7 +110,7 @@ public class PostAssignmentTest extends DataProvider {
     }
 
 
-    @Test(dataProvider = "invalidLatitudeValues")
+    @Test(dataProvider = "invalidLatitudeValues",dataProviderClass = DataProvider.class)
     @Story("As an admin user when I create an assignment with invalid latitude input I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidLatitude(Double invalidLatitude, String errorMessage) {
@@ -153,7 +153,7 @@ public class PostAssignmentTest extends DataProvider {
     }
 
 
-    @Test(dataProvider = "invalidFirstNamesAndLastDataForAssignment")
+    @Test(dataProvider = "invalidFirstNamesAndLastDataForAssignment",dataProviderClass = DataProvider.class)
     @Story("As an admin when I create an assignment with invalid first name I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidFirstName(String firstName, String errorMessage) {
@@ -166,7 +166,7 @@ public class PostAssignmentTest extends DataProvider {
                 .body("subErrors[0].type", equalTo("String"));
     }
 
-    @Test(dataProvider = "invalidFirstNamesAndLastDataForAssignment")
+    @Test(dataProvider = "invalidFirstNamesAndLastDataForAssignment",dataProviderClass = DataProvider.class)
     @Story("As an admin when I create an assignment with invalid last name I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidLastName(String lastName, String errorMessage) {

--- a/src/test/java/org/ays/tests/institution/assignmentmanagementservice/PostAssignmentTest.java
+++ b/src/test/java/org/ays/tests/institution/assignmentmanagementservice/PostAssignmentTest.java
@@ -35,7 +35,7 @@ public class PostAssignmentTest {
 
     }
 
-    @Test(dataProvider = "invalidDescriptionData",dataProviderClass = DataProvider.class)
+    @Test(dataProvider = "invalidDescriptionData", dataProviderClass = DataProvider.class)
     @Story("As an admin when I create an assignment with invalid description I want to get a proper error messages.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidDescription(String invalidDescription, String errorMessage) {
@@ -48,7 +48,7 @@ public class PostAssignmentTest {
                 .body("subErrors[0].type", equalTo("String"));
     }
 
-    @Test(dataProvider = "invalidCountryCodeData",dataProviderClass = DataProvider.class)
+    @Test(dataProvider = "invalidCountryCodeData", dataProviderClass = DataProvider.class)
     @Story("As an admin when I create an assignment with invalid country code input I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidCountryCode(String countryCode) {
@@ -72,7 +72,7 @@ public class PostAssignmentTest {
     }
 
 
-    @Test(dataProvider = "invalidLineNumberData",dataProviderClass = DataProvider.class)
+    @Test(dataProvider = "invalidLineNumberData", dataProviderClass = DataProvider.class)
     @Story("As an admin user when I create an assignment with invalid line number I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidLineNumber(String lineNumber) {
@@ -95,7 +95,7 @@ public class PostAssignmentTest {
         }
     }
 
-    @Test(dataProvider = "invalidLongitudeValues",dataProviderClass = DataProvider.class)
+    @Test(dataProvider = "invalidLongitudeValues", dataProviderClass = DataProvider.class)
     @Story("As an admin user when I create an assignment with invalid longitude input I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidLongitude(Double invalidLongitude, String errorMessage) {
@@ -110,7 +110,7 @@ public class PostAssignmentTest {
     }
 
 
-    @Test(dataProvider = "invalidLatitudeValues",dataProviderClass = DataProvider.class)
+    @Test(dataProvider = "invalidLatitudeValues", dataProviderClass = DataProvider.class)
     @Story("As an admin user when I create an assignment with invalid latitude input I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidLatitude(Double invalidLatitude, String errorMessage) {
@@ -153,7 +153,7 @@ public class PostAssignmentTest {
     }
 
 
-    @Test(dataProvider = "invalidFirstNamesAndLastDataForAssignment",dataProviderClass = DataProvider.class)
+    @Test(dataProvider = "invalidFirstNamesAndLastDataForAssignment", dataProviderClass = DataProvider.class)
     @Story("As an admin when I create an assignment with invalid first name I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidFirstName(String firstName, String errorMessage) {
@@ -166,7 +166,7 @@ public class PostAssignmentTest {
                 .body("subErrors[0].type", equalTo("String"));
     }
 
-    @Test(dataProvider = "invalidFirstNamesAndLastDataForAssignment",dataProviderClass = DataProvider.class)
+    @Test(dataProvider = "invalidFirstNamesAndLastDataForAssignment", dataProviderClass = DataProvider.class)
     @Story("As an admin when I create an assignment with invalid last name I want to get a proper error message.")
     @Severity(SeverityLevel.NORMAL)
     public void createAssignmentWithInvalidLastName(String lastName, String errorMessage) {

--- a/src/test/java/org/ays/tests/institution/assignmentmanagementservice/PostAssignmentsTest.java
+++ b/src/test/java/org/ays/tests/institution/assignmentmanagementservice/PostAssignmentsTest.java
@@ -1,31 +1,23 @@
 package org.ays.tests.institution.assignmentmanagementservice;
 
-import io.qameta.allure.Description;
-import io.qameta.allure.Severity;
-import io.qameta.allure.SeverityLevel;
-import io.qameta.allure.Story;
-import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.response.Response;
-import io.restassured.specification.ResponseSpecification;
 import org.ays.endpoints.InstitutionEndpoints;
 import org.ays.payload.Assignment;
 import org.ays.payload.Helper;
 import org.ays.payload.Pagination;
 import org.ays.payload.PhoneNumber;
 import org.ays.payload.RequestBodyAssignments;
+import org.ays.utility.AysResponseSpecs;
 import org.ays.utility.DataProvider;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.List;
-
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.notNullValue;
 
-public class PostAssignmentsTest extends DataProvider {
+public class PostAssignmentsTest {
     RequestBodyAssignments requestBodyAssignments;
 
     @BeforeMethod
@@ -33,78 +25,56 @@ public class PostAssignmentsTest extends DataProvider {
         requestBodyAssignments = new RequestBodyAssignments();
     }
 
-
-    @Test(dataProvider = "positivePaginationData")
-    @Story("As an admin user when I request data without providing any filter criteria, the system should return all available data without applying any filtering.")
-    @Severity(SeverityLevel.NORMAL)
+    @Test(groups = {"Smoke", "Regression", "Institution"}, dataProvider = "positivePaginationData", dataProviderClass = DataProvider.class)
     public void listAssignmentsWithPositivePaginationScenarios(int page, int pageSize) {
         requestBodyAssignments.setPagination(Helper.setPagination(page, pageSize));
         Response response = InstitutionEndpoints.listAssignments(requestBodyAssignments);
         response.then()
-                .spec(successResponseSpec())
-                .body("response.content", instanceOf(List.class))
-                .body("response.pageNumber", equalTo(page))
-                .body("response.totalPageCount", notNullValue())
-                .body("response.totalElementCount", notNullValue())
-                .body("response.sortedBy", equalTo(null))
-                .body("response.filteredB", equalTo(null));
-
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectUnfilteredListResponseSpec());
     }
 
-    @Test(dataProvider = "negativePaginationData")
-    @Story("As an admin when I request list all assignments I want to get a proper error message when pagination values are invalid")
-    @Severity(SeverityLevel.NORMAL)
+    @Test(groups = {"Regression", "Institution"}, dataProvider = "negativePaginationData", dataProviderClass = DataProvider.class)
     public void listAssignmentsWithNegativePaginationScenarios(int page, int pageSize) {
         requestBodyAssignments = Helper.createRequestBodyAssignments(page, pageSize);
         Response response = InstitutionEndpoints.listAssignments(requestBodyAssignments);
         response.then()
-                .spec(badRequestResponseSpec())
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec())
                 .body("subErrors[0].message", equalTo("must be between 1 and 99999999"))
                 .body("subErrors[0].field", anyOf(equalTo("page"), equalTo("pageSize")))
                 .body("subErrors[0].type", equalTo("int"));
 
     }
 
-    @Test()
-    @Story("As an admin when I request list all assignments as pagination values are null I want to get a proper error message")
-    @Severity(SeverityLevel.NORMAL)
+    @Test(groups = {"Regression", "Institution"})
     public void listAssignmentsWithNullPagination() {
         Pagination pagination = new Pagination();
         requestBodyAssignments.setPagination(pagination);
         Response response = InstitutionEndpoints.listAssignments(requestBodyAssignments);
         response.then()
-                .spec(badRequestResponseSpec())
-                .body("subErrors[0].message", equalTo("must be between 1 and 99999999"))
-                .body("subErrors[0].field", anyOf(equalTo("page"), equalTo("pageSize")))
-                .body("subErrors[0].type", equalTo("int"))
-                .body("subErrors[1].message", equalTo("must be between 1 and 99999999"))
-                .body("subErrors[1].field", anyOf(equalTo("page"), equalTo("pageSize")))
-                .body("subErrors[1].type", equalTo("int"));
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec())
+                .spec(AysResponseSpecs.expectInvalidPaginationErrors());
 
     }
 
-    @Test()
-    @Story("As an admin I want to filter assignments by phone number")
-    @Severity(SeverityLevel.NORMAL)
-    @Description("Prior to executing this method, an assignment is created to prevent failures in case no user is associated with the institution.")
+    @Test(groups = {"Regression", "Smoke", "Institution"}, description = "Prior to executing this method, an assignment is created to prevent failures in case no user is associated with the institution.")
     public void listAssignmentsWithValidPhoneNumberFilter() {
         Assignment assignment = Helper.createANewAssignment();
         requestBodyAssignments.setFilter(Helper.createFilterWithAssignmentPhoneNumber(assignment.getPhoneNumber()));
         requestBodyAssignments.setPagination(Helper.createPagination());
         Response response = InstitutionEndpoints.listAssignments(requestBodyAssignments);
         response.then()
-                .spec(successResponseSpec())
-                .spec(listAssignmentsResponseSpec(assignment))
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectAssignmentDetailsInContent())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
                 .body("response.filteredBy.statuses", equalTo(null))
                 .body("response.filteredBy.phoneNumber.countryCode", equalTo(assignment.getPhoneNumber().getCountryCode()))
                 .body("response.filteredBy.phoneNumber.lineNumber", equalTo(assignment.getPhoneNumber().getLineNumber()));
 
     }
 
-    @Test(dataProvider = "invalidPhoneNumberData")
-    @Story("As an admin I want to get a proper error message when I filter assignments with invalid phone number")
-    @Severity(SeverityLevel.NORMAL)
-    public void listAssignmentsWithInvalidPhoneNumberFilter(String countryCode, String lineNumber) {
+    @Test(groups = {"Regression", "Institution"}, dataProvider = "invalidPhoneNumberDataForFilter", dataProviderClass = DataProvider.class)
+    public void listAssignmentsWithInvalidPhoneNumberFilter(String countryCode, String lineNumber, String errorMessage) {
         PhoneNumber phoneNumber = new PhoneNumber();
         phoneNumber.setCountryCode(countryCode);
         phoneNumber.setLineNumber(lineNumber);
@@ -112,93 +82,64 @@ public class PostAssignmentsTest extends DataProvider {
         requestBodyAssignments.setFilter(Helper.createFilterWithAssignmentPhoneNumber(phoneNumber));
         Response response = InstitutionEndpoints.listAssignments(requestBodyAssignments);
         response.then()
-                .spec(badRequestResponseSpec())
-                .body("subErrors[0].message", equalTo("MUST BE VALID"))
-                .body("subErrors[0].field", equalTo("phoneNumber"))
-                .body("subErrors[0].type", equalTo("AysPhoneNumberFilterRequest"));
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec())
+                .body("subErrors[0].message", equalTo(errorMessage))
+                .body("subErrors[0].field", either(equalTo("lineNumber")).or(equalTo("countryCode")))
+                .body("subErrors[0].type", equalTo("String"));
 
     }
 
-    @Test()
-    @Story("As an admin I want to filter assignments by assignment status")
-    @Severity(SeverityLevel.NORMAL)
-    @Description("Prior to executing this method, an assignment is created to prevent failures in case no assignment is associated with the institution.")
-    public void listAssignmentsWithValidStatus() {
+    @Test(groups = {"Regression", "Smoke", "Institution"}, description = "Prior to executing this method, an assignment is created to prevent failures in case no user is associated with the institution.")
+    public void listAssignmentsWithValidStatusFilter() {
         Helper.createANewAssignment();
         requestBodyAssignments.setPagination(Helper.createPagination());
         requestBodyAssignments.setFilter(Helper.createFilterWithAssignmentStatus("AVAILABLE"));
         Response response = InstitutionEndpoints.listAssignments(requestBodyAssignments);
         response.then()
-                .spec(successResponseSpec())
-                .body("response.content[0].createdAt", notNullValue())
-                .body("response.content[0].createdUser", notNullValue())
-                .body("response.content[0].id", notNullValue())
-                .body("response.content[0].status", notNullValue())
-                .body("response.content[0].description", notNullValue())
-                .body("response.content[0].firstName", notNullValue())
-                .body("response.content[0].lastName", notNullValue())
-                .body("response.content[0].location", notNullValue())
-                .body("response.pageNumber", equalTo(1))
-                .body("response.totalPageCount", notNullValue())
-                .body("response.totalElementCount", notNullValue())
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectAssignmentDetailsInContent())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
                 .body("response.sortedBy", equalTo(null))
                 .body("response.filteredBy.statuses", hasItem("AVAILABLE"))
                 .body("response.filteredBy.phoneNumber", equalTo(null));
     }
 
-    @Test()
-    @Story("As an admin I want to get proper error message when I request to filter assignments with invalid status input")
-    @Severity(SeverityLevel.NORMAL)
-    @Description("Prior to executing this method, an assignment is created to prevent failures in case no assignment is associated with the institution.")
+    @Test(groups = {"Regression", "Institution"}, description = "Prior to executing this method, an assignment is created to prevent failures in case no user is associated with the institution.")
     public void listAssignmentsWithInvalidStatus() {
         Helper.createANewAssignment();
         requestBodyAssignments.setPagination(Helper.createPagination());
         requestBodyAssignments.setFilter(Helper.createFilterWithAssignmentStatus("available", "ASSIGNED"));
         Response response = InstitutionEndpoints.listAssignments(requestBodyAssignments);
         response.then()
-                .spec(badRequestResponseSpec());
-
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec());
     }
 
-    @Test()
-    @Story("As an admin I want to list assignments with valid status and linenumber and without country code")
-    @Severity(SeverityLevel.NORMAL)
-    @Description("Prior to executing this method, an assignment is created to prevent failures in case no assignment is associated with the institution.")
+    @Test(groups = {"Regression", "Smoke", "Institution"}, description = "Prior to executing this method, an assignment is created to prevent failures in case no user is associated with the institution.")
     public void listAssignmentsWithValidStatusAndLineNumber() {
         Assignment assignment = Helper.createANewAssignment();
         requestBodyAssignments.setPagination(Helper.createPagination());
         requestBodyAssignments.setFilter(Helper.createFilterWithAssignmentStatusAndLineNumber(assignment.getPhoneNumber().getLineNumber(), "AVAILABLE"));
         Response response = InstitutionEndpoints.listAssignments(requestBodyAssignments);
         response.then()
-                .spec(successResponseSpec())
-                .spec(listAssignmentsResponseSpec(assignment))
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectAssignmentDetailsInContent())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
                 .body("response.filteredBy.statuses", hasItem("AVAILABLE"))
                 .body("response.filteredBy.phoneNumber.lineNumber", equalTo(assignment.getPhoneNumber().getLineNumber()))
                 .body("response.filteredBy.phoneNumber.countryCode", equalTo(null));
 
     }
 
-    @Test()
-    @Story("As an admin I want to list assignments with valid status and country code and without line number")
-    @Severity(SeverityLevel.NORMAL)
-    @Description("Prior to executing this method, an assignment is created to prevent failures in case no assignment is associated with the institution.")
+    @Test(groups = {"Regression", "Smoke", "Institution"}, description = "Prior to executing this method, an assignment is created to prevent failures in case no user is associated with the institution.")
     public void listAssignmentsWithValidStatusAndCountryCode() {
         Assignment assignment = Helper.createANewAssignment();
         requestBodyAssignments.setPagination(Helper.createPagination());
         requestBodyAssignments.setFilter(Helper.createFilterWithAssignmentStatusAndCountryCOde(assignment.getPhoneNumber().getCountryCode(), "AVAILABLE"));
         Response response = InstitutionEndpoints.listAssignments(requestBodyAssignments);
         response.then()
-                .body("response.content[0].createdAt", notNullValue())
-                .body("response.content[0].createdUser", notNullValue())
-                .body("response.content[0].id", notNullValue())
-                .body("response.content[0].status", notNullValue())
-                .body("response.content[0].description", notNullValue())
-                .body("response.content[0].firstName", notNullValue())
-                .body("response.content[0].lastName", notNullValue())
-                .body("response.content[0].location", notNullValue())
-                .body("response.pageNumber", equalTo(1))
-                .body("response.totalPageCount", notNullValue())
-                .body("response.totalElementCount", notNullValue())
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectAssignmentDetailsInContent())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
                 .body("response.sortedBy", equalTo(null))
                 .body("response.filteredBy.statuses", hasItem("AVAILABLE"))
                 .body("response.filteredBy.phoneNumber.lineNumber", equalTo(null))
@@ -206,62 +147,20 @@ public class PostAssignmentsTest extends DataProvider {
 
     }
 
-    @Test()
-    @Story("As an admin I want to list assignments with valid status,linenumber,country code")
-    @Severity(SeverityLevel.NORMAL)
-    @Description("Prior to executing this method, an assignment is created to prevent failures in case no assignment is associated with the institution.")
+    @Test(groups = {"Regression", "Smoke", "Institution"}, description = "Prior to executing this method, an assignment is created to prevent failures in case no user is associated with the institution.")
     public void listAssignmentsWithValidStatusAndPhoneNumber() {
         Assignment assignment = Helper.createANewAssignment();
         requestBodyAssignments.setPagination(Helper.createPagination());
         requestBodyAssignments.setFilter(Helper.createFilterWithAssignmentStatusPhoneNumber(assignment.getPhoneNumber(), "AVAILABLE"));
         Response response = InstitutionEndpoints.listAssignments(requestBodyAssignments);
         response.then()
-                .spec(successResponseSpec())
-                .spec(listAssignmentsResponseSpec(assignment))
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectAssignmentDetailsInContent())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
                 .body("response.filteredBy.statuses", hasItem("AVAILABLE"))
                 .body("response.filteredBy.phoneNumber.lineNumber", equalTo(assignment.getPhoneNumber().getLineNumber()))
                 .body("response.filteredBy.phoneNumber.countryCode", equalTo(assignment.getPhoneNumber().getCountryCode()));
 
-    }
-
-
-    private ResponseSpecification successResponseSpec() {
-        return new ResponseSpecBuilder()
-                .expectStatusCode(200)
-                .expectContentType("application/json")
-                .expectBody("time", notNullValue())
-                .expectBody("httpStatus", equalTo("OK"))
-                .expectBody("isSuccess", equalTo(true))
-                .build();
-    }
-
-    private ResponseSpecification badRequestResponseSpec() {
-        return new ResponseSpecBuilder()
-                .expectStatusCode(400)
-                .expectContentType("application/json")
-                .expectBody("time", notNullValue())
-                .expectBody("httpStatus", equalTo("BAD_REQUEST"))
-                .expectBody("header", equalTo("VALIDATION ERROR"))
-                .expectBody("isSuccess", equalTo(false))
-                .build();
-    }
-
-    private ResponseSpecification listAssignmentsResponseSpec(Assignment assignment) {
-        return new ResponseSpecBuilder()
-                .expectBody("response.content", instanceOf(List.class))
-                .expectBody("response.content[0].createdAt", notNullValue())
-                .expectBody("response.content[0].createdUser", notNullValue())
-                .expectBody("response.content[0].id", notNullValue())
-                .expectBody("response.content[0].status", notNullValue())
-                .expectBody("response.content[0].description", equalTo(assignment.getDescription()))
-                .expectBody("response.content[0].firstName", equalTo(assignment.getFirstName()))
-                .expectBody("response.content[0].lastName", equalTo(assignment.getLastName()))
-                .expectBody("response.content[0].location", notNullValue())
-                .expectBody("response.pageNumber", equalTo(1))
-                .expectBody("response.totalPageCount", notNullValue())
-                .expectBody("response.totalElementCount", notNullValue())
-                .expectBody("response.sortedBy", equalTo(null))
-                .build();
     }
 
 }

--- a/src/test/java/org/ays/tests/institution/institutionservice/GetInstitutionsSummaryTest.java
+++ b/src/test/java/org/ays/tests/institution/institutionservice/GetInstitutionsSummaryTest.java
@@ -15,7 +15,7 @@ public class GetInstitutionsSummaryTest {
     public void listInstitutionsPositive() {
         Response response = InstitutionEndpoints.getInstitutionsSummary();
         response.then()
-                .spec(AysResponseSpecs.successResponseSpec());
+                .spec(AysResponseSpecs.expectSuccessResponseSpec());
 
         if (Helper.extractResponseAsList(response).isEmpty()) {
             AysLogUtil.info("There are no institutions");

--- a/src/test/java/org/ays/tests/institution/usermanagementservice/PostUsersTest.java
+++ b/src/test/java/org/ays/tests/institution/usermanagementservice/PostUsersTest.java
@@ -1,31 +1,25 @@
 package org.ays.tests.institution.usermanagementservice;
 
-import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.response.Response;
-import io.restassured.specification.ResponseSpecification;
 import org.ays.endpoints.InstitutionEndpoints;
 import org.ays.payload.Helper;
 import org.ays.payload.Pagination;
 import org.ays.payload.PhoneNumber;
 import org.ays.payload.RequestBodyUsers;
 import org.ays.payload.User;
+import org.ays.utility.AysLogUtil;
+import org.ays.utility.AysResponseSpecs;
 import org.ays.utility.DataProvider;
-import org.testng.Reporter;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.List;
-
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasItem;
 
-public class PostUsersTest extends DataProvider {
+public class PostUsersTest {
     RequestBodyUsers requestBodyUsers;
 
     @BeforeMethod
@@ -33,81 +27,67 @@ public class PostUsersTest extends DataProvider {
         requestBodyUsers = new RequestBodyUsers();
     }
 
-    @Test()
+    @Test(groups = {"Smoke", "Regression", "Institution"})
     public void validateUserDetailsInUsersList() {
         requestBodyUsers.setPagination(Helper.createPagination());
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         if (response.jsonPath().getList("response.content").isEmpty()) {
-            Reporter.log("No users under this institution.");
+            AysLogUtil.info("No users under this institution.");
         } else {
             response.then()
-                    .body("response.content[0]", hasKey("id"))
-                    .body("response.content[0]", hasKey("firstName"))
-                    .body("response.content[0]", hasKey("lastName"))
-                    .body("response.content[0]", hasKey("status"))
-                    .body("response.content[0]", hasKey("role"))
-                    .body("response.content[0]", hasKey("supportStatus"))
-                    .body("response.content[0]", hasKey("createdAt"));
+                    .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                    .spec(AysResponseSpecs.expectUserDetailsInContent())
+                    .spec(AysResponseSpecs.expectUnfilteredListResponseSpec());
         }
     }
 
-    @Test(dataProvider = "positivePaginationData")
+    @Test(groups = {"Smoke", "Regression", "Institution"}, dataProvider = "positivePaginationData", dataProviderClass = DataProvider.class)
     public void listUsersWithPositivePaginationScenarios(int page, int pageSize) {
         requestBodyUsers.setPagination(Helper.setPagination(page, pageSize));
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(successResponseSpec())
-                .body("response.content", instanceOf(List.class))
-                .body("response.pageNumber", equalTo(page))
-                .body("response.totalPageCount", notNullValue())
-                .body("response.totalElementCount", notNullValue())
-                .body("response", hasKey("sortedBy"))
-                .body("response", hasKey("filteredBy"));
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectUnfilteredListResponseSpec());
 
     }
 
-    @Test(dataProvider = "negativePaginationData")
+    @Test(groups = {"Regression", "Institution"}, dataProvider = "negativePaginationData", dataProviderClass = DataProvider.class)
     public void listUsersWithNegativePaginationScenarios(int page, int pageSize) {
         requestBodyUsers.setPagination(Helper.setPagination(page, pageSize));
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(badRequestResponseSpec())
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec())
                 .body("subErrors[0].message", equalTo("must be between 1 and 99999999"))
                 .body("subErrors[0].field", anyOf(equalTo("page"), equalTo("pageSize")))
                 .body("subErrors[0].type", equalTo("int"));
 
     }
 
-    @Test()
+    @Test(groups = {"Regression", "Institution"})
     public void listUsersWithNullPagination() {
         Pagination pagination = new Pagination();
         requestBodyUsers.setPagination(pagination);
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(badRequestResponseSpec())
-                .body("subErrors[0].message", equalTo("must be between 1 and 99999999"))
-                .body("subErrors[0].field", anyOf(equalTo("page"), equalTo("pageSize")))
-                .body("subErrors[0].type", equalTo("int"))
-                .body("subErrors[1].message", equalTo("must be between 1 and 99999999"))
-                .body("subErrors[1].field", anyOf(equalTo("page"), equalTo("pageSize")))
-                .body("subErrors[1].type", equalTo("int"));
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec())
+                .spec(AysResponseSpecs.expectInvalidPaginationErrors());
 
     }
 
-    @Test(dataProvider = "invalidNames")
+    @Test(groups = {"Regression", "Institution"}, dataProvider = "invalidNames", dataProviderClass = DataProvider.class)
     public void listUsersWithNegativeNameScenariosFilter(String firstname, String lastname, String errorMessage) {
         requestBodyUsers.setFilter(Helper.createFilterWithUserFirstAndLastName(firstname, lastname));
         requestBodyUsers.setPagination(Helper.createPagination());
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(badRequestResponseSpec())
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec())
                 .body("subErrors[0].message", equalTo(errorMessage))
                 .body("subErrors[0].field", anyOf(equalTo("lastName"), equalTo("firstName")))
                 .body("subErrors[0].type", equalTo("String"));
 
     }
 
-    @Test(description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
+    @Test(groups = {"Smoke", "Regression", "Institution"}, description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
     public void listUsersWithValidUserNameFilter() {
         User user = Helper.createUserPayload();
         InstitutionEndpoints.createAUser(user);
@@ -115,83 +95,64 @@ public class PostUsersTest extends DataProvider {
         requestBodyUsers.setPagination(Helper.createPagination());
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(successResponseSpec())
-                .body("response.content", hasSize(greaterThan(0)))
-                .body("response.content[0].id", notNullValue())
-                .body("response.content[0].firstName", equalTo(user.getFirstName()))
-                .body("response.content[0].lastName", equalTo(user.getLastName()))
-                .body("response.content[0].status", equalTo("ACTIVE"))
-                .body("response.content[0].role", equalTo("VOLUNTEER"))
-                .body("response.content[0].supportStatus", equalTo("IDLE"))
-                .body("response.content[0].createdAt", notNullValue())
-                .body("response.pageNumber", equalTo(1))
-                .body("response.totalPageCount", notNullValue())
-                .body("response.totalElementCount", notNullValue())
-                .body("response", hasKey("sortedBy"))
-                .body("response", hasKey("filteredBy"));
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
+                .spec(AysResponseSpecs.expectUserDetailsInContent())
+                .body("response.sortedBy", equalTo(null))
+                .body("response.filteredBy.firstName", equalTo(user.getFirstName()))
+                .body("response.filteredBy.lastName", equalTo(user.getLastName()));
     }
 
-    @Test(description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
+    @Test(groups = {"Smoke", "Regression", "Institution"}, description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
     public void listUsersWithValidStatusFilter() {
-        User user = Helper.createUserPayload();
-        InstitutionEndpoints.createAUser(user);
+        Helper.createNewUser();
         requestBodyUsers.setFilter(Helper.createFilterWithUserStatus("ACTIVE"));
         requestBodyUsers.setPagination(Helper.createPagination());
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(successResponseSpec())
-                .body("response.content", hasSize(greaterThan(0)))
-                .body("response.content[0].id", notNullValue())
-                .body("response.content[0].firstName", notNullValue())
-                .body("response.content[0].lastName", notNullValue())
-                .body("response.content[0].status", equalTo("ACTIVE"))
-                .body("response.content[0].role", equalTo("VOLUNTEER"))
-                .body("response.content[0].createdAt", notNullValue())
-                .body("response.pageNumber", equalTo(1))
-                .body("response.totalPageCount", notNullValue())
-                .body("response.totalElementCount", notNullValue())
-                .body("response", hasKey("sortedBy"))
-                .body("response", hasKey("filteredBy"));
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
+                .spec(AysResponseSpecs.expectUserDetailsInContent())
+                .body("response.sortedBy", equalTo(null))
+                .body("response.filteredBy.statuses", hasItem("ACTIVE"))
+                .body("response.content*.status", everyItem(equalTo("ACTIVE")));
     }
 
-    @Test(description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
+    @Test(groups = {"Regression", "Institution"}, description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
     public void listUsersWithInvalidStatusFilter() {
-        User user = Helper.createUserPayload();
-        InstitutionEndpoints.createAUser(user);
+        Helper.createNewUser();
         requestBodyUsers.setFilter(Helper.createFilterWithUserStatus("ACT"));
         requestBodyUsers.setPagination(Helper.createPagination());
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(badRequestResponseSpec());
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec());
     }
 
-    @Test(description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
+    @Test(groups = {"Smoke", "Regression", "Institution"}, description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
     public void listUsersWithValidSupportStatusFilter() {
         Helper.createNewUser();
         requestBodyUsers.setFilter(Helper.createFilterWithUserSupportStatus("IDLE"));
         requestBodyUsers.setPagination(Helper.createPagination());
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(successResponseSpec())
-                .body("response.content", hasSize(greaterThan(0)))
-                .body("response.content[0].supportStatus", equalTo("IDLE"))
-                .body("response.pageNumber", equalTo(1))
-                .body("response.totalPageCount", notNullValue())
-                .body("response.totalElementCount", notNullValue())
-                .body("response", hasKey("sortedBy"))
-                .body("response", hasKey("filteredBy"));
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
+                .spec(AysResponseSpecs.expectUserDetailsInContent())
+                .body("response.sortedBy", equalTo(null))
+                .body("response.filteredBy.supportStatuses", hasItem("IDLE"))
+                .body("response.content*.supportStatus", everyItem(equalTo("IDLE")));
     }
 
-    @Test()
+    @Test(groups = {"Regression", "Institution"})
     public void listUsersWithInvalidSupportStatusFilter() {
         requestBodyUsers.setFilter(Helper.createFilterWithUserSupportStatus("Ready"));
         requestBodyUsers.setPagination(Helper.createPagination());
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(badRequestResponseSpec());
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec());
     }
 
-    @Test(description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
+    @Test(groups = {"Smoke", "Regression", "Institution"}, description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
     public void listUsersWithValidPhoneNumberFilter() {
         User user = Helper.createUserPayload();
         InstitutionEndpoints.createAUser(user);
@@ -199,23 +160,17 @@ public class PostUsersTest extends DataProvider {
         requestBodyUsers.setPagination(Helper.createPagination());
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(successResponseSpec())
-                .body("response.content", hasSize(greaterThan(0)))
-                .body("response.content[0].id", notNullValue())
-                .body("response.content[0].firstName", equalTo(user.getFirstName()))
-                .body("response.content[0].lastName", equalTo(user.getLastName()))
-                .body("response.content[0].status", equalTo("ACTIVE"))
-                .body("response.content[0].role", equalTo("VOLUNTEER"))
-                .body("response.content[0].supportStatus", equalTo("IDLE"))
-                .body("response.pageNumber", equalTo(1))
-                .body("response.totalPageCount", notNullValue())
-                .body("response.totalElementCount", notNullValue())
-                .body("response", hasKey("sortedBy"))
-                .body("response", hasKey("filteredBy"));
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
+                .spec(AysResponseSpecs.expectUserDetailsInContent())
+                .body("response.sortedBy", equalTo(null))
+                .body("response.filteredBy.phoneNumber.countryCode", equalTo(user.getPhoneNumber().getCountryCode()))
+                .body("response.filteredBy.phoneNumber.lineNumber", equalTo(user.getPhoneNumber().getLineNumber()));
+
     }
 
-    @Test(dataProvider = "invalidPhoneNumberData", description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
-    public void listUsersWithInvalidPhoneNumberFilter(String countryCode, String lineNumber) {
+    @Test(groups = {"Regression", "Institution"}, dataProvider = "invalidPhoneNumberDataForFilter", dataProviderClass = DataProvider.class, description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
+    public void listUsersWithInvalidPhoneNumberFilter(String countryCode, String lineNumber, String errorMessage) {
         Helper.createNewUser();
         PhoneNumber phoneNumber = new PhoneNumber();
         phoneNumber.setCountryCode(countryCode);
@@ -224,14 +179,14 @@ public class PostUsersTest extends DataProvider {
         requestBodyUsers.setPagination(Helper.createPagination());
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(badRequestResponseSpec())
-                .body("subErrors[0].message", equalTo("MUST BE VALID"))
-                .body("subErrors[0].field", equalTo("phoneNumber"))
-                .body("subErrors[0].type", equalTo("AysPhoneNumberFilterRequest"));
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec())
+                .body("subErrors[0].message", equalTo(errorMessage))
+                .body("subErrors[0].field", either(equalTo("lineNumber")).or(equalTo("countryCode")))
+                .body("subErrors[0].type", equalTo("String"));
 
     }
 
-    @Test(description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
+    @Test(groups = {"Smoke", "Regression", "Institution"}, description = "Prior to executing this method, a user is created to prevent failures in case no user is associated with the institution.")
     public void listUsersWithValidFiltersAndSort() {
         User user = Helper.createUserPayload();
         InstitutionEndpoints.createAUser(user);
@@ -240,36 +195,36 @@ public class PostUsersTest extends DataProvider {
         requestBodyUsers.setPagination(Helper.createPagination());
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(successResponseSpec())
-                .body("response.content", hasSize(greaterThan(0)))
-                .body("response.content[0].id", notNullValue())
-                .body("response.content[0].firstName", equalTo(user.getFirstName()))
-                .body("response.content[0].lastName", equalTo(user.getLastName()))
-                .body("response.content[0].status", equalTo("ACTIVE"))
-                .body("response.content[0].role", equalTo("VOLUNTEER"))
-                .body("response.content[0].supportStatus", equalTo("IDLE"))
-                .body("response.pageNumber", equalTo(1))
-                .body("response.totalPageCount", notNullValue())
-                .body("response.totalElementCount", notNullValue())
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
+                .spec(AysResponseSpecs.expectUserDetailsInContent())
                 .body("response.sortedBy[0].property", equalTo("createdAt"))
                 .body("response.sortedBy[0].direction", equalTo("ASC"))
-                .body("response.filteredBy", nullValue());
+                .body("response.filteredBy.firstName", equalTo(user.getFirstName()))
+                .body("response.filteredBy.lastName", equalTo(user.getLastName()))
+                .body("response.filteredBy.supportStatuses", hasItem("IDLE"))
+                .body("response.filteredBy.statuses", hasItem("ACTIVE"))
+                .body("response.filteredBy.phoneNumber.countryCode", equalTo(user.getPhoneNumber().getCountryCode()))
+                .body("response.filteredBy.phoneNumber.lineNumber", equalTo(user.getPhoneNumber().getLineNumber()));
     }
 
-    @Test()
+    @Test(groups = {"Smoke", "Regression", "Institution"})
     public void listUsersWithValidSortOptionsInAscendingOrder() {
         requestBodyUsers.setPagination(Helper.createPagination());
         requestBodyUsers.setSort(Helper.createSortBody("createdAt", "ASC"));
         Response ascResponse = InstitutionEndpoints.listUsers(requestBodyUsers);
         ascResponse.then()
-                .spec(successResponseSpec())
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
+                .spec(AysResponseSpecs.expectUserDetailsInContent())
+                .body("response.filteredBy", equalTo(null))
                 .body("response.sortedBy[0].property", equalTo("createdAt"))
                 .body("response.sortedBy[0].direction", equalTo("ASC"));
 
     }
 
-    @Test(description = "Prior to executing this method, two users are created to prevent failures in case no user is associated with the institution and validate DESC order.")
-    public void sortUsersWithValidSortOptionsInDescendingOrder() {
+    @Test(groups = {"Smoke", "Regression", "Institution"}, description = "Prior to executing this method, two users are created to prevent failures in case no user is associated with the institution and validate DESC order.")
+    public void listUsersWithValidSortOptionsInDescendingOrder() {
         User user1 = Helper.createUserPayload();
         InstitutionEndpoints.createAUser(user1);
         User user2 = Helper.createUserPayload();
@@ -279,46 +234,27 @@ public class PostUsersTest extends DataProvider {
         requestBodyUsers.setSort(Helper.createSortBody("createdAt", "DESC"));
         Response ascResponse = InstitutionEndpoints.listUsers(requestBodyUsers);
         ascResponse.then()
-                .spec(successResponseSpec())
+                .spec(AysResponseSpecs.expectSuccessResponseSpec())
+                .spec(AysResponseSpecs.expectDefaultListingDetails())
                 .body("response.content[0].firstName", equalTo(user2.getFirstName()))
                 .body("response.content[0].lastName", equalTo(user2.getLastName()))
                 .body("response.content[1].firstName", equalTo(user1.getFirstName()))
                 .body("response.content[1].lastName", equalTo(user1.getLastName()))
+                .body("response.filteredBy", equalTo(null))
                 .body("response.sortedBy[0].property", equalTo("createdAt"))
                 .body("response.sortedBy[0].direction", equalTo("DESC"));
 
     }
 
-    @Test(dataProvider = "negativeSortData")
+    @Test(groups = {"Smoke", "Regression", "Institution"}, dataProvider = "negativeSortData", dataProviderClass = DataProvider.class)
     public void sortUsersWithInvalidSortOptions(String property, String direction, String errorMessage) {
         requestBodyUsers.setPagination(Helper.createPagination());
         requestBodyUsers.setSort(Helper.createSortBody(property, direction));
         Response response = InstitutionEndpoints.listUsers(requestBodyUsers);
         response.then()
-                .spec(badRequestResponseSpec())
+                .spec(AysResponseSpecs.expectBadRequestResponseSpec())
                 .body("subErrors[0].message", equalTo(errorMessage));
 
-    }
-
-    private ResponseSpecification successResponseSpec() {
-        return new ResponseSpecBuilder()
-                .expectStatusCode(200)
-                .expectContentType("application/json")
-                .expectBody("time", notNullValue())
-                .expectBody("httpStatus", equalTo("OK"))
-                .expectBody("isSuccess", equalTo(true))
-                .build();
-    }
-
-    private ResponseSpecification badRequestResponseSpec() {
-        return new ResponseSpecBuilder()
-                .expectStatusCode(400)
-                .expectContentType("application/json")
-                .expectBody("time", notNullValue())
-                .expectBody("httpStatus", equalTo("BAD_REQUEST"))
-                .expectBody("header", equalTo("VALIDATION ERROR"))
-                .expectBody("isSuccess", equalTo(false))
-                .build();
     }
 
 }

--- a/src/test/java/org/ays/utility/AysResponseSpecs.java
+++ b/src/test/java/org/ays/utility/AysResponseSpecs.java
@@ -3,14 +3,19 @@ package org.ays.utility;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.specification.ResponseSpecification;
 import lombok.experimental.UtilityClass;
+import org.hamcrest.Matchers;
+
+import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 
 @UtilityClass
 public class AysResponseSpecs {
 
-    public static ResponseSpecification successResponseSpec() {
+    public static ResponseSpecification expectSuccessResponseSpec() {
         return new ResponseSpecBuilder()
                 .expectStatusCode(200)
                 .expectContentType("application/json")
@@ -20,7 +25,7 @@ public class AysResponseSpecs {
                 .build();
     }
 
-    public static ResponseSpecification badRequestResponseSpec() {
+    public static ResponseSpecification expectBadRequestResponseSpec() {
         return new ResponseSpecBuilder()
                 .expectStatusCode(400)
                 .expectContentType("application/json")
@@ -31,7 +36,7 @@ public class AysResponseSpecs {
                 .build();
     }
 
-    public static ResponseSpecification unauthorizedResponseSpec() {
+    public static ResponseSpecification expectUnauthorizedResponseSpec() {
         return new ResponseSpecBuilder()
                 .expectStatusCode(401)
                 .expectContentType("application/json")
@@ -42,7 +47,7 @@ public class AysResponseSpecs {
                 .build();
     }
 
-    public static ResponseSpecification getTokenResponseSpec() {
+    public static ResponseSpecification expectGetTokenResponseSpec() {
         return new ResponseSpecBuilder()
                 .expectBody("response.accessToken", notNullValue())
                 .expectBody("response.accessTokenExpiresAt", notNullValue())
@@ -50,11 +55,64 @@ public class AysResponseSpecs {
                 .build();
     }
 
-    public static ResponseSpecification nullCredentialFieldErrorSpec(String field) {
+    public static ResponseSpecification expectNullCredentialFieldErrorSpec(String field) {
         return new ResponseSpecBuilder()
                 .expectBody("subErrors[0].message", equalTo("must not be blank"))
                 .expectBody("subErrors[0].field", equalTo(field))
                 .expectBody("subErrors[0].type", equalTo("String"))
+                .build();
+    }
+
+    public static ResponseSpecification expectUnfilteredListResponseSpec() {
+        return new ResponseSpecBuilder()
+                .expectBody("response.content", instanceOf(List.class))
+                .expectBody("response.pageNumber", notNullValue())
+                .expectBody("response.totalPageCount", notNullValue())
+                .expectBody("response.totalElementCount", notNullValue())
+                .expectBody("response.sortedBy", equalTo(null))
+                .expectBody("response.filteredBy", equalTo(null))
+                .build();
+    }
+
+    public static ResponseSpecification expectAssignmentDetailsInContent() {
+        return new ResponseSpecBuilder()
+                .expectBody("response.content[0].createdAt", notNullValue())
+                .expectBody("response.content[0].createdUser", notNullValue())
+                .expectBody("response.content[0].id", notNullValue())
+                .expectBody("response.content[0].status", notNullValue())
+                .expectBody("response.content[0].description", notNullValue())
+                .expectBody("response.content[0].firstName", notNullValue())
+                .expectBody("response.content[0].lastName", notNullValue())
+                .expectBody("response.content[0].location", notNullValue())
+                .build();
+    }
+
+    public static ResponseSpecification expectUserDetailsInContent() {
+        return new ResponseSpecBuilder()
+                .expectBody("response.content[0].id", notNullValue())
+                .expectBody("response.content[0].firstName", notNullValue())
+                .expectBody("response.content[0].lastName", notNullValue())
+                .expectBody("response.content[0].status", notNullValue())
+                .expectBody("response.content[0].role", notNullValue())
+                .expectBody("response.content[0].supportStatus", notNullValue())
+                .expectBody("response.content[0].createdAt", notNullValue())
+                .build();
+    }
+
+    public static ResponseSpecification expectDefaultListingDetails() {
+        return new ResponseSpecBuilder()
+                .expectBody("response.content", instanceOf(List.class))
+                .expectBody("response.pageNumber", notNullValue())
+                .expectBody("response.totalPageCount", notNullValue())
+                .expectBody("response.totalElementCount", notNullValue())
+                .build();
+    }
+
+    public static ResponseSpecification expectInvalidPaginationErrors() {
+        return new ResponseSpecBuilder()
+                .expectBody("subErrors*.message", everyItem(equalTo("must be between 1 and 99999999")))
+                .expectBody("subErrors*.field", everyItem(Matchers.anyOf(equalTo("page"), equalTo("pageSize"))))
+                .expectBody("subErrors*.type", everyItem(equalTo("int")))
                 .build();
     }
 

--- a/src/test/java/org/ays/utility/DataProvider.java
+++ b/src/test/java/org/ays/utility/DataProvider.java
@@ -1,7 +1,9 @@
 package org.ays.utility;
 
+import lombok.experimental.UtilityClass;
 import org.ays.payload.Helper;
 
+@UtilityClass
 public class DataProvider {
     @org.testng.annotations.DataProvider(name = "positivePaginationData")
     public static Object[][] positivePaginationData() {
@@ -42,11 +44,11 @@ public class DataProvider {
     public static Object[][] invalidNames() {
         return new Object[][]{
                 {"Noah", "Patricia1", "MUST BE VALID"},
+                {".Noah", "Patricia1", "MUST BE VALID"},
                 {" John", "Doe", "NAME MUST NOT START OR END WITH WHITESPACE"},
                 {"Alice", "Johnson ", "NAME MUST NOT START OR END WITH WHITESPACE"},
                 {"@#$%", "%^&*", "MUST BE VALID"},
                 {"123", "Smith", "MUST BE VALID"},
-                {"Emma", "Br@wn", "MUST BE VALID"},
                 {"A", "B", "NAME MUST BE BETWEEN 2 AND 255 CHARACTERS LONG"},
                 {"A".repeat(256), "Doe", "NAME MUST BE BETWEEN 2 AND 255 CHARACTERS LONG"},
                 {"Jane", "B".repeat(256), "NAME MUST BE BETWEEN 2 AND 255 CHARACTERS LONG"}
@@ -77,7 +79,7 @@ public class DataProvider {
     }
 
     @org.testng.annotations.DataProvider(name = "invalidCountryCodeData")
-    public Object[][] countryCodeData() {
+    public static Object[][] countryCodeData() {
         return new Object[][]{
                 {null},
                 {""},
@@ -89,7 +91,7 @@ public class DataProvider {
     }
 
     @org.testng.annotations.DataProvider(name = "invalidLineNumberData")
-    public Object[][] lineNumberData() {
+    public static Object[][] lineNumberData() {
         return new Object[][]{
                 {Helper.generateInvalidLineNumber()},
                 {Helper.generateLineNumber() + "*"},
@@ -100,7 +102,7 @@ public class DataProvider {
     }
 
     @org.testng.annotations.DataProvider(name = "invalidLongitudeValues")
-    public Object[][] invalidLongitudeValues() {
+    public static Object[][] invalidLongitudeValues() {
         return new Object[][]{
                 {180.000000001, "must be less than or equal to 180"},
                 {-180.000000001, "must be greater than or equal to -180"},
@@ -114,7 +116,7 @@ public class DataProvider {
     }
 
     @org.testng.annotations.DataProvider(name = "invalidLatitudeValues")
-    public Object[][] invalidLatitudeValues() {
+    public static Object[][] invalidLatitudeValues() {
         return new Object[][]{
                 {100.0, "must be less than or equal to 90"},
                 {-100.0, "must be greater than or equal to -90"},
@@ -127,7 +129,7 @@ public class DataProvider {
     }
 
     @org.testng.annotations.DataProvider(name = "invalidFirstNamesAndLastDataForAssignment")
-    public Object[][] invalidFirstAndLastNamesDataForAssignment() {
+    public static Object[][] invalidFirstAndLastNamesDataForAssignment() {
         return new Object[][]{
                 {"", "must not be blank"},
                 {null, "must not be blank"},
@@ -143,7 +145,7 @@ public class DataProvider {
     }
 
     @org.testng.annotations.DataProvider(name = "invalidRejectReason")
-    public Object[][] invalidRejectReason() {
+    public static Object[][] invalidRejectReason() {
         return new Object[][]{
                 {"A".repeat(39)},
                 {"A".repeat(513)}
@@ -151,12 +153,23 @@ public class DataProvider {
     }
 
     @org.testng.annotations.DataProvider(name = "invalidDataForPostApplicationReasonField")
-    public Object[][] invalidDataForPostApplicationReasonField() {
+    public static Object[][] invalidDataForPostApplicationReasonField() {
         return new Object[][]{
                 {"reason less then forty", "size must be between 40 and 512", "reason", "String"},
                 {null, "must not be blank", "reason", "String"},
                 {"       ", "size must be between 40 and 512", "reason", "String"},
                 {"A".repeat(513), "size must be between 40 and 512", "reason", "String"}
+        };
+    }
+
+    @org.testng.annotations.DataProvider(name = "invalidPhoneNumberDataForFilter")
+    public static Object[][] invalidPhoneNumberDataForFilter() {
+        return new Object[][]{
+                {"", "1234567890", "size must be between 1 and 3"},
+                {"12345", "1234567890", "size must be between 1 and 3"},
+                {"90", "", "size must be between 7 and 15"},
+                {"90", "12345", "size must be between 7 and 15"},
+                {"90", "1234567890123456", "size must be between 7 and 15"}
         };
     }
 


### PR DESCRIPTION


## Pull Request

**Description:**
Update phone number test data for list users and assignments endpoints

**Related Issue:**
Closes #[AYS-161]

**Changes Made:**
-Applied AysResponseSpecs class to improve assertion consistency in PostUsersTest and PostAssignmentsTest classes
-Converted DataProvider class into a Utility Class for better organization and removed usage of extend version
-Added new response specs to AysResponseSpecs specifically for PostUsersTest and PostAssignmentsTest classes
-Added a new invalid phone number data provider in DataProvider class for filter scenarios
-Grouped tests as Smoke or Regression in PostUsersTest and PostAssignmentsTest classes for better categorization and management
**Additional Information:**

## Checklist
- [x] I have read and followed the [contribution guidelines](README.md#contributing) for this project.
- [x] I have added tests 
- [x] All tests are passing.
- [x] I have updated the documentation 

## Reviewer Instructions

[AYS-161]: https://afetyonetimsistemi.atlassian.net/browse/AYS-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ