### PR TITLE
AYS-272 | Automate GET/api/v1/permissions endpoint

### DIFF
--- a/src/test/java/org/ays/endpoints/Authorization.java
+++ b/src/test/java/org/ays/endpoints/Authorization.java
@@ -3,6 +3,7 @@ package org.ays.endpoints;
 import io.restassured.response.Response;
 import lombok.experimental.UtilityClass;
 import org.ays.payload.AdminCredentials;
+import org.ays.payload.SourcePage;
 import org.ays.payload.UserCredentials;
 import org.ays.utility.AysConfigurationProperty;
 
@@ -13,6 +14,7 @@ public class Authorization {
         AdminCredentials superAdminCredentials = new AdminCredentials();
         superAdminCredentials.setEmailAddress(AysConfigurationProperty.SuperAdminUserOne.EMAIL_ADDRESS);
         superAdminCredentials.setPassword(AysConfigurationProperty.SuperAdminUserOne.PASSWORD);
+        superAdminCredentials.setSourcePage(SourcePage.INSTITUTION);
 
         Response response = InstitutionAuthEndpoints.getAdminToken(superAdminCredentials);
 
@@ -28,6 +30,7 @@ public class Authorization {
         AdminCredentials adminCredentials = new AdminCredentials();
         adminCredentials.setEmailAddress(AysConfigurationProperty.InstitutionOne.AdminUserOne.EMAIL_ADDRESS);
         adminCredentials.setPassword(AysConfigurationProperty.InstitutionOne.AdminUserOne.PASSWORD);
+        adminCredentials.setSourcePage(SourcePage.INSTITUTION);
 
         Response response = InstitutionAuthEndpoints.getAdminToken(adminCredentials);
 

--- a/src/test/java/org/ays/endpoints/InstitutionEndpoints.java
+++ b/src/test/java/org/ays/endpoints/InstitutionEndpoints.java
@@ -236,4 +236,26 @@ public class InstitutionEndpoints {
         return AysRestAssured.perform(restAssuredRequest);
     }
 
+    public static Response getAdminsPermissions() {
+
+        AysRestAssuredRequest restAssuredRequest = AysRestAssuredRequest.builder()
+                .httpMethod(HttpMethod.GET)
+                .url("/api/v1/permissions")
+                .token(Authorization.loginAndGetAdminAccessToken())
+                .build();
+
+        return AysRestAssured.perform(restAssuredRequest);
+    }
+
+    public static Response getSuperAdminsPermissions() {
+
+        AysRestAssuredRequest restAssuredRequest = AysRestAssuredRequest.builder()
+                .httpMethod(HttpMethod.GET)
+                .url("/api/v1/permissions")
+                .token(Authorization.loginAndGetSuperAdminAccessToken())
+                .build();
+
+        return AysRestAssured.perform(restAssuredRequest);
+    }
+
 }

--- a/src/test/java/org/ays/tests/institution/permissionService/GetPermissionsTest.java
+++ b/src/test/java/org/ays/tests/institution/permissionService/GetPermissionsTest.java
@@ -1,0 +1,60 @@
+package org.ays.tests.institution.permissionService;
+
+import io.restassured.response.Response;
+import org.ays.endpoints.InstitutionEndpoints;
+import org.ays.utility.AysResponseSpecs;
+import org.ays.utility.DatabaseUtility;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.ays.utility.DatabaseUtility.getColumNameFromTableWhereValueIs;
+
+public class GetPermissionsTest {
+
+    @Test(groups = {"Smoke", "Regression"})
+    public void nonSuperUsersShouldNotSeeSuperPermissions() {
+
+        Response response = InstitutionEndpoints.getAdminsPermissions();
+        response.then()
+                .spec(AysResponseSpecs.expectSuccessResponseSpec());
+
+        List<String> listOfNameValuesFromResponse = response.jsonPath().getList("response.name");
+        List<String> listOfNameValuesFromDB = getColumNameFromTableWhereValueIs("name", "AYS_PERMISSION", "IS_SUPER", "1");
+
+        for (String dbName : listOfNameValuesFromDB) {
+            Assert.assertFalse(listOfNameValuesFromResponse.contains(dbName), "Name from database found in response: " + dbName);
+        }
+    }
+
+    @Test(groups = {"Regression"})
+    public void nonSuperUsersShouldSeeNonSuperPermissions() {
+
+        Response response = InstitutionEndpoints.getAdminsPermissions();
+        response.then()
+                .spec(AysResponseSpecs.expectSuccessResponseSpec());
+
+        List<String> listOfNameValuesFromResponse = response.jsonPath().getList("response.name");
+        List<String> listOfNameValuesFromDB = getColumNameFromTableWhereValueIs("name", "AYS_PERMISSION", "IS_SUPER", "0");
+
+        for (String dbName : listOfNameValuesFromDB) {
+            Assert.assertTrue(listOfNameValuesFromResponse.contains(dbName), "Name from database found in response: " + dbName);
+        }
+    }
+
+    @Test(groups = {"Smoke", "Regression", "SuperAdmin"})
+    public void superUsersShouldSeeAllPermissions() {
+
+        Response response = InstitutionEndpoints.getSuperAdminsPermissions();
+        response.then()
+                .spec(AysResponseSpecs.expectSuccessResponseSpec());
+
+        Set<String> setOfNameValuesFromResponse = new HashSet<>(response.jsonPath().getList("response.name"));
+        Set<String> setOfNameValuesFromDB = new HashSet<>(DatabaseUtility.getColumNameFromTableWhereValueIs("name", "AYS_PERMISSION"));
+
+        Assert.assertEquals(setOfNameValuesFromResponse, setOfNameValuesFromDB, "The names from the response and the database do not match.");
+    }
+}

--- a/src/test/java/org/ays/utility/DatabaseUtility.java
+++ b/src/test/java/org/ays/utility/DatabaseUtility.java
@@ -2,11 +2,9 @@ package org.ays.utility;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 public class DatabaseUtility {
@@ -35,4 +33,40 @@ public class DatabaseUtility {
         }
     }
 
+    public static List<String> getColumNameFromTableWhereValueIs(String columnName, String tableName) {
+        return getColumNameFromTableWhereValueIs(columnName, tableName, null, null);
+    }
+
+    // Overloaded method to fetch column values from a table with a WHERE clause
+    public static List<String> getColumNameFromTableWhereValueIs(String columnName, String tableName, String filterName, Object filterValue) {
+        List<String> valuesInColumn = new ArrayList<>();
+
+        String query = "SELECT " + columnName + " FROM " + tableName;
+
+        if (filterName != null && filterValue != null) {
+            query += " WHERE " + filterName + " = ?";
+        }
+
+        try {
+            // Ensure the connection is established
+            if (connection == null || connection.isClosed()) {
+                DBConnection();
+            }
+
+            try (PreparedStatement preparedStatement = connection.prepareStatement(query)) {
+                if (filterName != null && filterValue != null) {
+                    preparedStatement.setObject(1, filterValue);
+                }
+                try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                    while (resultSet.next()) {
+                        valuesInColumn.add(resultSet.getString(columnName));
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        return valuesInColumn;
+    }
 }

--- a/src/test/resources/testsuite/RegressionSuite.xml
+++ b/src/test/resources/testsuite/RegressionSuite.xml
@@ -17,6 +17,7 @@
             <class name="org.ays.tests.auth.landingAuthServiceTests.GetUserTokenTest"/>
             <class name="org.ays.tests.auth.landingAuthServiceTests.PostUserInvalidateTokenTest"/>
             <class name="org.ays.tests.auth.landingAuthServiceTests.PostUserTokenRefreshTest"/>
+            <class name="org.ays.tests.institution.permissionService.GetPermissionsTest"/>
         </classes>
     </test>
 </suite>

--- a/src/test/resources/testsuite/SmokeSuite.xml
+++ b/src/test/resources/testsuite/SmokeSuite.xml
@@ -29,6 +29,7 @@
             <class name="org.ays.tests.user.selfmanagementservice.GetUserSelfTest"/>
             <class name="org.ays.tests.user.selfmanagementservice.PutUserSelfStatusSupportTest"/>
             <class name="org.ays.tests.institution.institutionservice.GetInstitutionsSummaryTest"/>
+            <class name="org.ays.tests.institution.permissionService.GetPermissionsTest"/>
         </classes>
     </test>
 </suite>

--- a/src/test/resources/testsuite/SuperAdminTestSuite.xml
+++ b/src/test/resources/testsuite/SuperAdminTestSuite.xml
@@ -14,6 +14,7 @@
             <class name="org.ays.tests.institution.adminregistrationmanagementservice.PostAdminRegistrationApplicationsTest"/>
             <class name="org.ays.tests.institution.adminregistrationmanagementservice.PostAdminRegistrationApplicationApproveTest"/>
             <class name="org.ays.tests.institution.adminregistrationmanagementservice.PostAdminRegistrationApplicationRejectTest"/>
+            <class name="org.ays.tests.institution.permissionService.GetPermissionsTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Pull Request

**Description:**
This pull request includes the changes about adding test for GET/api/v1 permissions endpoint. 

**Related Issue:**
Closes #[AYS-272]

**Changes Made:**
1. Add test for GET/api/v1/permissions and create util method to execute SELECT query
2. Update xml test runners with GET/api/v1/permissions test
3. Set sourcePage value for superAdmin and admin access tokens

**Additional Information:**
Tests that cause errors will be fixed within the scope of ticket AYS-275.

## Checklist
- [ yes ] I have read and followed the [contribution guidelines](README.md#contributing) for this project.
- [ yes ] I have added tests (if applicable).
- [ no ] All tests are passing.
- [ no ] I have updated the documentation (if necessary).

## Reviewer Instructions
See **Additional Information**.

[AYS-272]: https://afetyonetimsistemi.atlassian.net/browse/AYS-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ