### PR TITLE
AYS-582 | Password Reset Functionality For User Statuses

### DIFF
--- a/src/test/java/org/ays/auth/datasource/UserDataSource.java
+++ b/src/test/java/org/ays/auth/datasource/UserDataSource.java
@@ -129,4 +129,24 @@ public class UserDataSource {
         }
     }
 
+    public static String findLastCreatedUserStatusByInstitutionId(String institutionId) {
+        String query = "SELECT STATUS FROM AYS_USER WHERE INSTITUTION_ID = ? ORDER BY CREATED_AT DESC LIMIT 1";
+
+        try (Connection connection = AysDataSource.createConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(query)) {
+
+            preparedStatement.setString(1, institutionId);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getString("STATUS");
+                }
+            }
+
+            throw new RuntimeException("No user found for the given institution ID");
+        } catch (SQLException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+
 }

--- a/src/test/java/org/ays/auth/datasource/UserDataSource.java
+++ b/src/test/java/org/ays/auth/datasource/UserDataSource.java
@@ -148,5 +148,4 @@ public class UserDataSource {
         }
     }
 
-
 }

--- a/src/test/java/org/ays/auth/endpoints/UserEndpoints.java
+++ b/src/test/java/org/ays/auth/endpoints/UserEndpoints.java
@@ -63,24 +63,24 @@ public class UserEndpoints {
         return AysRestAssured.perform(restAssuredPayload);
     }
 
-    public static Response passivate(String userId, String token) {
+    public static Response passivate(String id, String token) {
 
         AysRestAssuredPayload restAssuredPayload = AysRestAssuredPayload.builder()
                 .httpMethod(HttpMethod.PATCH)
                 .url("/api/v1/user/{id}/passivate")
-                .pathParameter(Map.of("id", userId))
+                .pathParameter(Map.of("id", id))
                 .token(token)
                 .build();
 
         return AysRestAssured.perform(restAssuredPayload);
     }
 
-    public static Response activate(String userId, String token) {
+    public static Response activate(String id, String token) {
 
         AysRestAssuredPayload restAssuredPayload = AysRestAssuredPayload.builder()
                 .httpMethod(HttpMethod.PATCH)
                 .url("/api/v1/user/{id}/activate")
-                .pathParameter(Map.of("id", userId))
+                .pathParameter(Map.of("id", id))
                 .token(token)
                 .build();
 

--- a/src/test/java/org/ays/auth/endpoints/UserEndpoints.java
+++ b/src/test/java/org/ays/auth/endpoints/UserEndpoints.java
@@ -63,6 +63,30 @@ public class UserEndpoints {
         return AysRestAssured.perform(restAssuredPayload);
     }
 
+    public static Response passivate(String userId, String token) {
+
+        AysRestAssuredPayload restAssuredPayload = AysRestAssuredPayload.builder()
+                .httpMethod(HttpMethod.PATCH)
+                .url("/api/v1/user/{id}/passivate")
+                .pathParameter(Map.of("id", userId))
+                .token(token)
+                .build();
+
+        return AysRestAssured.perform(restAssuredPayload);
+    }
+
+    public static Response activate(String userId, String token) {
+
+        AysRestAssuredPayload restAssuredPayload = AysRestAssuredPayload.builder()
+                .httpMethod(HttpMethod.PATCH)
+                .url("/api/v1/user/{id}/activate")
+                .pathParameter(Map.of("id", userId))
+                .token(token)
+                .build();
+
+        return AysRestAssured.perform(restAssuredPayload);
+    }
+
     public static Response delete(String userId, String token) {
 
         AysRestAssuredPayload restAssuredPayload = AysRestAssuredPayload.builder()

--- a/src/test/java/org/ays/auth/model/enums/UserStatus.java
+++ b/src/test/java/org/ays/auth/model/enums/UserStatus.java
@@ -2,5 +2,7 @@ package org.ays.auth.model.enums;
 
 public enum UserStatus {
     ACTIVE,
-    PASSIVE
+    PASSIVE,
+    NOT_VERIFIED,
+    DELETED
 }

--- a/src/test/java/org/ays/auth/tests/PasswordForgotTest.java
+++ b/src/test/java/org/ays/auth/tests/PasswordForgotTest.java
@@ -120,7 +120,7 @@ public class PasswordForgotTest {
 
     }
 
-    @Test(groups = {"Smoke", "Regression"})
+    @Test(groups = {"Regression"})
     public void forgotPasswordForActiveUsers() {
         LoginPayload loginPayload = LoginPayload.generateAsTestDisasterFoundationAdmin();
         String accessToken = this.loginAndGetAccessToken(loginPayload);
@@ -168,7 +168,7 @@ public class PasswordForgotTest {
                 .TestVolunteerFoundation.ID);
 
         Response response = AuthEndpoints.forgotPassword(passwordForgotPayload);
-        
+
         Assert.assertEquals(userStatus, UserStatus.NOT_VERIFIED.name());
 
         response.then()

--- a/src/test/java/org/ays/auth/tests/PasswordForgotTest.java
+++ b/src/test/java/org/ays/auth/tests/PasswordForgotTest.java
@@ -31,8 +31,9 @@ import java.util.List;
 import static org.testng.Assert.assertNotEquals;
 
 public class PasswordForgotTest {
+
     @Test(groups = {"Smoke", "Regression"})
-    public void forgotPasswordForUsersHavingInstitutionPagePermissions() {
+    public void forgotPasswordForActiveUsersHavingInstitutionPagePermissions() {
         LoginPayload loginPayload = LoginPayload.generateAsTestDisasterFoundationAdmin();
         String accessToken = this.loginAndGetAccessToken(loginPayload);
 
@@ -118,28 +119,6 @@ public class PasswordForgotTest {
         assertNotEquals(firstResponseTime, secondResponseTime,
                 "The time value is the same in the first and second response.");
 
-    }
-
-    @Test(groups = {"Regression"})
-    public void forgotPasswordForActiveUsers() {
-        LoginPayload loginPayload = LoginPayload.generateAsTestDisasterFoundationAdmin();
-        String accessToken = this.loginAndGetAccessToken(loginPayload);
-
-        String institutionPermission = PermissionDataSource.findPermissionIdByName(Permission.INSTITUTION_PAGE.getPermission());
-        RoleCreatePayload roleCreatePayload = RoleCreatePayload.generate(List.of(institutionPermission));
-        RoleEndpoints.create(roleCreatePayload, accessToken);
-        String roleId = RoleDataSource.findLastCreatedRoleIdByInstitutionId(AysConfigurationProperty.TestDisasterFoundation.ID);
-
-        UserCreatePayload userCreatePayload = UserCreatePayload.generateUserWithARole(roleId);
-        UserEndpoints.create(userCreatePayload, accessToken);
-
-        PasswordForgotPayload passwordForgotPayload = new PasswordForgotPayload();
-        String emailAddress = userCreatePayload.getEmailAddress();
-        passwordForgotPayload.setEmailAddress(emailAddress);
-
-        Response response = AuthEndpoints.forgotPassword(passwordForgotPayload);
-        response.then()
-                .spec(AysResponseSpecs.expectSuccessResponseSpec());
     }
 
     @Test(groups = {"Regression"})

--- a/src/test/java/org/ays/auth/tests/PasswordForgotTest.java
+++ b/src/test/java/org/ays/auth/tests/PasswordForgotTest.java
@@ -3,10 +3,13 @@ package org.ays.auth.tests;
 import io.restassured.response.Response;
 import org.ays.auth.datasource.PermissionDataSource;
 import org.ays.auth.datasource.RoleDataSource;
+import org.ays.auth.datasource.UserDataSource;
 import org.ays.auth.endpoints.AuthEndpoints;
 import org.ays.auth.endpoints.RoleEndpoints;
 import org.ays.auth.endpoints.UserEndpoints;
 import org.ays.auth.model.enums.Permission;
+import org.ays.auth.model.enums.UserStatus;
+import org.ays.auth.payload.AdminRegistrationApplicationCompletePayload;
 import org.ays.auth.payload.LoginPayload;
 import org.ays.auth.payload.PasswordForgotPayload;
 import org.ays.auth.payload.RoleCreatePayload;
@@ -14,7 +17,12 @@ import org.ays.auth.payload.UserCreatePayload;
 import org.ays.common.model.enums.AysErrorMessage;
 import org.ays.common.util.AysConfigurationProperty;
 import org.ays.common.util.AysDataProvider;
+import org.ays.common.util.AysRandomUtil;
 import org.ays.common.util.AysResponseSpecs;
+import org.ays.registrationapplication.datasource.AdminRegistrationApplicationDataSource;
+import org.ays.registrationapplication.endpoints.AdminRegistrationApplicationEndpoints;
+import org.ays.registrationapplication.model.payload.AdminRegistrationApplicationCreatePayload;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Collections;
@@ -109,6 +117,75 @@ public class PasswordForgotTest {
 
         assertNotEquals(firstResponseTime, secondResponseTime,
                 "The time value is the same in the first and second response.");
+
+    }
+
+    @Test(groups = {"Smoke", "Regression"})
+    public void forgotPasswordForActiveUsers() {
+        LoginPayload loginPayload = LoginPayload.generateAsTestDisasterFoundationAdmin();
+        String accessToken = this.loginAndGetAccessToken(loginPayload);
+
+        String institutionPermission = PermissionDataSource.findPermissionIdByName(Permission.INSTITUTION_PAGE.getPermission());
+        RoleCreatePayload roleCreatePayload = RoleCreatePayload.generate(List.of(institutionPermission));
+        RoleEndpoints.create(roleCreatePayload, accessToken);
+        String roleId = RoleDataSource.findLastCreatedRoleIdByInstitutionId(AysConfigurationProperty.TestDisasterFoundation.ID);
+
+        UserCreatePayload userCreatePayload = UserCreatePayload.generateUserWithARole(roleId);
+        UserEndpoints.create(userCreatePayload, accessToken);
+
+        PasswordForgotPayload passwordForgotPayload = new PasswordForgotPayload();
+        String emailAddress = userCreatePayload.getEmailAddress();
+        passwordForgotPayload.setEmailAddress(emailAddress);
+
+        Response response = AuthEndpoints.forgotPassword(passwordForgotPayload);
+        response.then()
+                .spec(AysResponseSpecs.expectSuccessResponseSpec());
+
+    }
+
+    @Test(groups = {"Regression"})
+    public void forgotPasswordForNotVerifiedUsers() {
+        LoginPayload loginPayload = LoginPayload.generateAsTestVolunteerFoundationSuperAdmin();
+        String accessToken = this.loginAndGetAccessToken(loginPayload);
+
+        AdminRegistrationApplicationCreatePayload application = AdminRegistrationApplicationCreatePayload
+                .generate(AysConfigurationProperty.TestVolunteerFoundation.ID, AysRandomUtil.generateReasonString());
+        AdminRegistrationApplicationEndpoints.create(application, accessToken);
+
+        String applicationId = AdminRegistrationApplicationDataSource.findLastCreatedId();
+
+        AdminRegistrationApplicationCompletePayload applicationCompletePayload = AdminRegistrationApplicationCompletePayload
+                .generate();
+        AdminRegistrationApplicationEndpoints.complete(applicationId, applicationCompletePayload, accessToken);
+
+        String notVerifiedUserEmailAddress = applicationCompletePayload.getEmailAddress();
+
+        PasswordForgotPayload passwordForgotPayload = new PasswordForgotPayload();
+        passwordForgotPayload.setEmailAddress(notVerifiedUserEmailAddress);
+
+        String userStatus = UserDataSource.findLastCreatedUserStatusByInstitutionId(AysConfigurationProperty
+                .TestVolunteerFoundation.ID);
+
+        Assert.assertEquals(userStatus, UserStatus.NOT_VERIFIED.name());
+
+        Response response = AuthEndpoints.forgotPassword(passwordForgotPayload);
+        response.then()
+                .spec(AysResponseSpecs.expectUnauthorizedResponseSpec());
+
+    }
+
+    @Test(groups = {"Regression"})
+    public void forgotPasswordForPassiveUsers() {
+        LoginPayload loginPayload = LoginPayload.generateAsTestDisasterFoundationAdmin();
+        String accessToken = this.loginAndGetAccessToken(loginPayload);
+
+        String institutionPermission = PermissionDataSource.findPermissionIdByName(Permission.INSTITUTION_PAGE.getPermission());
+        RoleCreatePayload roleCreatePayload = RoleCreatePayload.generate(List.of(institutionPermission));
+        RoleEndpoints.create(roleCreatePayload, accessToken);
+        String roleId = RoleDataSource.findLastCreatedRoleIdByInstitutionId(AysConfigurationProperty.TestDisasterFoundation.ID);
+
+        UserCreatePayload userCreatePayload = UserCreatePayload.generateUserWithARole(roleId);
+        UserEndpoints.create(userCreatePayload, accessToken);
 
     }
 

--- a/src/test/java/org/ays/auth/tests/PasswordForgotTest.java
+++ b/src/test/java/org/ays/auth/tests/PasswordForgotTest.java
@@ -140,7 +140,6 @@ public class PasswordForgotTest {
         Response response = AuthEndpoints.forgotPassword(passwordForgotPayload);
         response.then()
                 .spec(AysResponseSpecs.expectSuccessResponseSpec());
-
     }
 
     @Test(groups = {"Regression"})
@@ -163,8 +162,8 @@ public class PasswordForgotTest {
         PasswordForgotPayload passwordForgotPayload = new PasswordForgotPayload();
         passwordForgotPayload.setEmailAddress(notVerifiedUserEmailAddress);
 
-        String userStatus = UserDataSource.findLastCreatedUserStatusByInstitutionId(AysConfigurationProperty
-                .TestVolunteerFoundation.ID);
+        String userStatus = UserDataSource
+                .findLastCreatedUserStatusByInstitutionId(AysConfigurationProperty.TestVolunteerFoundation.ID);
 
         Response response = AuthEndpoints.forgotPassword(passwordForgotPayload);
 
@@ -172,7 +171,6 @@ public class PasswordForgotTest {
 
         response.then()
                 .spec(AysResponseSpecs.expectUnauthorizedResponseSpec());
-
     }
 
     @Test(groups = {"Regression"})
@@ -196,8 +194,8 @@ public class PasswordForgotTest {
         String passiveUserEmailAddress = userCreatePayload.getEmailAddress();
         passwordForgotPayload.setEmailAddress(passiveUserEmailAddress);
 
-        String userStatus = UserDataSource.findLastCreatedUserStatusByInstitutionId(AysConfigurationProperty
-                .TestDisasterFoundation.ID);
+        String userStatus = UserDataSource
+                .findLastCreatedUserStatusByInstitutionId(AysConfigurationProperty.TestDisasterFoundation.ID);
 
         Response response = AuthEndpoints.forgotPassword(passwordForgotPayload);
 
@@ -205,7 +203,6 @@ public class PasswordForgotTest {
 
         response.then()
                 .spec(AysResponseSpecs.expectUnauthorizedResponseSpec());
-
     }
 
     @Test(groups = {"Regression"})
@@ -229,8 +226,8 @@ public class PasswordForgotTest {
         String passiveUserEmailAddress = userCreatePayload.getEmailAddress();
         passwordForgotPayload.setEmailAddress(passiveUserEmailAddress);
 
-        String userStatus = UserDataSource.findLastCreatedUserStatusByInstitutionId(AysConfigurationProperty
-                .TestDisasterFoundation.ID);
+        String userStatus = UserDataSource
+                .findLastCreatedUserStatusByInstitutionId(AysConfigurationProperty.TestDisasterFoundation.ID);
 
         Response response = AuthEndpoints.forgotPassword(passwordForgotPayload);
 
@@ -238,7 +235,6 @@ public class PasswordForgotTest {
 
         response.then()
                 .spec(AysResponseSpecs.expectUnauthorizedResponseSpec());
-
     }
 
     private String loginAndGetAccessToken(LoginPayload loginPayload) {

--- a/src/test/java/org/ays/auth/tests/PasswordForgotTest.java
+++ b/src/test/java/org/ays/auth/tests/PasswordForgotTest.java
@@ -126,7 +126,6 @@ public class PasswordForgotTest {
         String accessToken = this.loginAndGetAccessToken(loginPayload);
 
         String institutionPermission = PermissionDataSource.findPermissionIdByName(Permission.INSTITUTION_PAGE.getPermission());
-
         RoleCreatePayload roleCreatePayload = RoleCreatePayload.generate(List.of(institutionPermission));
         RoleEndpoints.create(roleCreatePayload, accessToken);
         String roleId = RoleDataSource.findLastCreatedRoleIdByInstitutionId(AysConfigurationProperty.TestDisasterFoundation.ID);


### PR DESCRIPTION
## Pull Request

**Description:**

- This PR adds comprehensive test cases for the Password Forgot api to ensure that it behaves as expected based on the user's status.

**Changes Made:**

1. Added test methods to verify API behavior for different user statuses:

- forgotPasswordForActiveUsers()
- forgotPasswordForNotVerifiedUsers()
- forgotPasswordForPassiveUsers()
- forgotPasswordForDeletedUsers()

2. Added `activate` and `passivate` endpoint methods to the `UserEndpoints` class

**Additional Information:**
Add any additional information that might be relevant to reviewers.

**Reviewer Instructions:**
Provide instructions or guidelines for reviewers to follow when assessing your pull request.

### Checklist

Before submitting your pull request, ensure the following:

- [x] **Title and Branch Naming Conventions:**
    - The pull request title follows the
      standard: [Pull Request Naming Conventions](https://github.com/afet-yonetim-sistemi/ays-be-api-automation/blob/main/CONTRIBUTING.md#pull-request-naming-conventions)
      .
    - The branch name follows one of the conventions outlined in
      the [Branch Naming Conventions](https://github.com/afet-yonetim-sistemi/ays-be-api-automation/blob/main/CONTRIBUTING.md#branch-naming-conventions)
      .

- [x] **Local Testing:**
    - I have added positive and negative test scenarios (if applicable)
    - All tests are passing.
    - I tagged all test as smoke or regression
    - I added newly added tests to related xml file in test suite

- [x] **Code Quality:**
    - The code is formatted according to the project's coding guidelines and style.
    - The code has been reviewed to ensure its quality.
    - The code does not contain any issues flagged by SonarLint.

- [x] **Documentation:**
    - Necessary documentation has been added or existing documentation has been updated.

- [x] **Reviewers and Assignees:**
    - Default reviewers have been assigned to this pull request.
    - Assignees have been added if necessary.

- [x] **Labels and Associations:**
    - No specific actions are required in the Labels and Associations section for this pull request.

- [x] **Reviewer Instructions:**
    - Provide instructions or guidelines for reviewers to follow when assessing your pull request.

